### PR TITLE
chore: set CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @DeFiGeek-Community/dapps


### PR DESCRIPTION
https://stackoverflow.com/questions/62759666/how-to-restrict-who-can-merge-to-master-on-a-github-repo#:~:text=No%2C%20GitHub%20doesn't%20let,in%20the%20branch%20protection%20settings.