### PR TITLE
fix issue#108

### DIFF
--- a/src/components/Pledge/Collateral/DepositInput.tsx
+++ b/src/components/Pledge/Collateral/DepositInput.tsx
@@ -117,20 +117,21 @@ export default function DepositInput(props: Props) {
               >
                 預入実行
               </CustomButton>
-            </HStack>
+            </HStack>            
             {deposit > 0 && (
-              <HStack spacing={4} align="flex-end">
+              <VStack spacing={4} align="start">
                 <CustomFormLabel
-                  text={`変動予測値表示...${
+                  text={`変動予測値表示 ${
                     formatPrice(addToNum(collateral, deposit), 'jpy').value
-                  }${
-                    YAMATO_SYMBOL.COLLATERAL
-                  }, 担保率${formatCollateralizationRatio(
+                  }${YAMATO_SYMBOL.COLLATERAL}`}
+                />
+                <CustomFormLabel
+                  text={`担保率 ${formatCollateralizationRatio(
                     (collateral + deposit) * rateOfEthJpy,
                     debt
                   )}%`}
                 />
-              </HStack>
+              </VStack>
             )}
           </VStack>
         </Form>

--- a/src/components/Pledge/Collateral/DepositInput.tsx
+++ b/src/components/Pledge/Collateral/DepositInput.tsx
@@ -117,7 +117,7 @@ export default function DepositInput(props: Props) {
               >
                 預入実行
               </CustomButton>
-            </HStack>            
+            </HStack>
             {deposit > 0 && (
               <VStack spacing={4} align="start">
                 <CustomFormLabel

--- a/src/components/Pledge/Collateral/WithdrawalInput.tsx
+++ b/src/components/Pledge/Collateral/WithdrawalInput.tsx
@@ -117,19 +117,19 @@ export default function WithdrawalInput(props: Props) {
               </CustomButton>
             </HStack>
             {withdrawal > 0 && (
-              <HStack spacing={4} align="flex-end">
+              <VStack spacing={4} align="start">
                 <CustomFormLabel
-                  text={`変動予測値表示...${
-                    formatPrice(subtractToNum(collateral, withdrawal), 'jpy')
-                      .value
-                  }${
-                    YAMATO_SYMBOL.COLLATERAL
-                  }, 担保率${formatCollateralizationRatio(
+                  text={`変動予測値表示 ${
+                    formatPrice(subtractToNum(collateral, withdrawal), 'jpy').value
+                  }${YAMATO_SYMBOL.COLLATERAL}`}
+                />
+                <CustomFormLabel
+                  text={`担保率${formatCollateralizationRatio(
                     (collateral - withdrawal) * rateOfEthJpy,
                     debt
                   )}%`}
                 />
-              </HStack>
+              </VStack>
             )}
           </VStack>
         </Form>

--- a/src/components/Pledge/Collateral/WithdrawalInput.tsx
+++ b/src/components/Pledge/Collateral/WithdrawalInput.tsx
@@ -124,7 +124,7 @@ export default function WithdrawalInput(props: Props) {
                   }${YAMATO_SYMBOL.COLLATERAL}`}
                 />
                 <CustomFormLabel
-                  text={`担保率${formatCollateralizationRatio(
+                  text={`担保率 ${formatCollateralizationRatio(
                     (collateral - withdrawal) * rateOfEthJpy,
                     debt
                   )}%`}

--- a/src/components/Pledge/Collateral/WithdrawalInput.tsx
+++ b/src/components/Pledge/Collateral/WithdrawalInput.tsx
@@ -120,7 +120,8 @@ export default function WithdrawalInput(props: Props) {
               <VStack spacing={4} align="start">
                 <CustomFormLabel
                   text={`変動予測値表示 ${
-                    formatPrice(subtractToNum(collateral, withdrawal), 'jpy').value
+                    formatPrice(subtractToNum(collateral, withdrawal), 'jpy')
+                      .value
                   }${YAMATO_SYMBOL.COLLATERAL}`}
                 />
                 <CustomFormLabel

--- a/src/components/Pledge/Collateral/index.tsx
+++ b/src/components/Pledge/Collateral/index.tsx
@@ -13,73 +13,77 @@ export default function Collateral() {
   const { collateral, debt } = usePledgeData();
 
   return (
-    <Grid templateColumns="repeat(8, 1fr)" gap={4} mb={4}>
-      <GridItem colSpan={1}>
-        <ItemTitleForPledge marginTop={26}>担保量</ItemTitleForPledge>
-      </GridItem>
+    <>
+      <Grid templateColumns="repeat(8, 1fr)" gap={4} mb={4}>
+        <GridItem colSpan={1}>
+          <ItemTitleForPledge marginTop={26}>担保量</ItemTitleForPledge>
+        </GridItem>
 
-      <GridItem colSpan={1}>
-        <ItemTitleValue
-          marginTop={26}
-          data-testid="collateral-data-currentAmount"
-        >
-          {firstLoadCompleted ? (
-            <>
-              {formatPrice(collateral, 'eth').value}
-              {YAMATO_SYMBOL.COLLATERAL}
-            </>
-          ) : (
-            <Skeleton
-              height="1.4rem"
-              width="7rem"
-              style={{
-                lineHeight: '1.4rem',
-              }}
-            />
-          )}
-        </ItemTitleValue>
-      </GridItem>
+        <GridItem colSpan={1}>
+          <ItemTitleValue
+            marginTop={26}
+            data-testid="collateral-data-currentAmount"
+          >
+            {firstLoadCompleted ? (
+              <>
+                {formatPrice(collateral, 'eth').value}
+                {YAMATO_SYMBOL.COLLATERAL}
+              </>
+            ) : (
+              <Skeleton
+                height="1.4rem"
+                width="7rem"
+                style={{
+                  lineHeight: '1.4rem',
+                }}
+              />
+            )}
+          </ItemTitleValue>
+        </GridItem>
 
-      <GridItem colSpan={3}>
-        <DepositInput
-          collateral={collateral}
-          debt={debt}
-          rateOfEthJpy={rateOfEthJpy}
-        />
-      </GridItem>
+        <GridItem colSpan={3}>
+          <DepositInput
+            collateral={collateral}
+            debt={debt}
+            rateOfEthJpy={rateOfEthJpy}
+          />
+        </GridItem>
 
-      <GridItem colSpan={3}>
-        <WithdrawalInput
-          collateral={collateral}
-          debt={debt}
-          rateOfEthJpy={rateOfEthJpy}
-        />
-      </GridItem>
+        <GridItem colSpan={3}>
+          <WithdrawalInput
+            collateral={collateral}
+            debt={debt}
+            rateOfEthJpy={rateOfEthJpy}
+          />
+        </GridItem>
+      </Grid>
 
-      <GridItem colSpan={1}>
-        <ItemTitleForPledge marginTop={26}>評価額</ItemTitleForPledge>
-      </GridItem>
-      <GridItem colSpan={1}>
-        <ItemTitleValue marginTop={26}>
-          {firstLoadCompleted ? (
-            <>
-              ¥
-              {
-                formatPrice(multiplyToNum(collateral, rateOfEthJpy), 'jpy')
-                  .value
-              }
-            </>
-          ) : (
-            <Skeleton
-              height="1.4rem"
-              width="7rem"
-              style={{
-                lineHeight: '1.4rem',
-              }}
-            />
-          )}
-        </ItemTitleValue>
-      </GridItem>
-    </Grid>
+      <Grid templateColumns="repeat(8, 1fr)" gap={4} mb={4}>
+        <GridItem colSpan={1}>
+          <ItemTitleForPledge marginTop={26}>評価額</ItemTitleForPledge>
+        </GridItem>
+        <GridItem colSpan={1}>
+          <ItemTitleValue marginTop={26}>
+            {firstLoadCompleted ? (
+              <>
+                ¥
+                {
+                  formatPrice(multiplyToNum(collateral, rateOfEthJpy), 'jpy')
+                    .value
+                }
+              </>
+            ) : (
+              <Skeleton
+                height="1.4rem"
+                width="7rem"
+                style={{
+                  lineHeight: '1.4rem',
+                }}
+              />
+            )}
+          </ItemTitleValue>
+        </GridItem>
+      </Grid>
+    </>
   );
 }

--- a/src/components/Pledge/Debt/BorrowingInput.tsx
+++ b/src/components/Pledge/Debt/BorrowingInput.tsx
@@ -133,26 +133,23 @@ export default function BorrowingInput(props: Props) {
               </CustomButton>
             </HStack>
             {borrowing > 0 && (
-              <HStack spacing={4} align="flex-end">
-                <VStack align="stretch">
-                  <CustomFormLabel
-                    text={`変動予測値表示...${
-                      formatPrice(
-                        addToNum(debt, borrowing - feeResult.fee),
-                        'jpy'
-                      ).value
-                    }${YAMATO_SYMBOL.YEN}, 担保率${formatCollateralizationRatio(
-                      collateral * rateOfEthJpy,
-                      debt + borrowing
-                    )}%`}
-                  />
-                  <CustomFormLabel
-                    text={`手数料${formatPrice(feeResult.fee, 'jpy').value}${
-                      YAMATO_SYMBOL.YEN
-                    }(手数料率${feeResult.feeRate.toFixed(2)}%)`}
-                  />
-                </VStack>
-              </HStack>
+              <VStack spacing={4} align="start">
+                <CustomFormLabel
+                  text={`変動予測値表示 ${formatPrice(
+                    addToNum(debt, borrowing - feeResult.fee),'jpy').value
+                    }${YAMATO_SYMBOL.YEN}`}
+                />
+                <CustomFormLabel
+                  text={`担保率 ${formatCollateralizationRatio(
+                    collateral * rateOfEthJpy,
+                    debt + borrowing
+                  )}%`}
+                />
+                <CustomFormLabel
+                  text={`手数料 ${formatPrice(feeResult.fee, 'jpy').value}${YAMATO_SYMBOL.YEN
+                    }(手数料率 ${feeResult.feeRate.toFixed(2)}%)`}
+                />
+              </VStack>
             )}
           </VStack>
         </Form>

--- a/src/components/Pledge/Debt/BorrowingInput.tsx
+++ b/src/components/Pledge/Debt/BorrowingInput.tsx
@@ -135,9 +135,12 @@ export default function BorrowingInput(props: Props) {
             {borrowing > 0 && (
               <VStack spacing={4} align="start">
                 <CustomFormLabel
-                  text={`変動予測値表示 ${formatPrice(
-                    addToNum(debt, borrowing - feeResult.fee),'jpy').value
-                    }${YAMATO_SYMBOL.YEN}`}
+                  text={`変動予測値表示 ${
+                    formatPrice(
+                      addToNum(debt, borrowing - feeResult.fee),
+                      'jpy'
+                    ).value
+                  }${YAMATO_SYMBOL.YEN}`}
                 />
                 <CustomFormLabel
                   text={`担保率 ${formatCollateralizationRatio(
@@ -146,8 +149,9 @@ export default function BorrowingInput(props: Props) {
                   )}%`}
                 />
                 <CustomFormLabel
-                  text={`手数料 ${formatPrice(feeResult.fee, 'jpy').value}${YAMATO_SYMBOL.YEN
-                    }(手数料率 ${feeResult.feeRate.toFixed(2)}%)`}
+                  text={`手数料 ${formatPrice(feeResult.fee, 'jpy').value}${
+                    YAMATO_SYMBOL.YEN
+                  }(手数料率 ${feeResult.feeRate.toFixed(2)}%)`}
                 />
               </VStack>
             )}

--- a/src/components/Pledge/Debt/RepayInput.tsx
+++ b/src/components/Pledge/Debt/RepayInput.tsx
@@ -135,16 +135,19 @@ export default function RepayInput(props: Props) {
               </CustomButton>
             </HStack>
             {repayment > 0 && (
-              <HStack spacing={4} align="flex-end">
+              <VStack spacing={4} align="start">
                 <CustomFormLabel
-                  text={`変動予測値表示...${
+                  text={`変動予測値表示 ${
                     formatPrice(subtractToNum(debt, repayment), 'jpy').value
-                  }${YAMATO_SYMBOL.YEN}, 担保率${formatCollateralizationRatio(
+                  }${YAMATO_SYMBOL.YEN}`}
+                />
+                <CustomFormLabel
+                  text={`担保率 ${formatCollateralizationRatio(
                     collateral * rateOfEthJpy,
                     debt - repayment
                   )}%`}
                 />
-              </HStack>
+              </VStack>
             )}
           </VStack>
         </Form>

--- a/src/components/Pledge/Debt/index.tsx
+++ b/src/components/Pledge/Debt/index.tsx
@@ -54,7 +54,8 @@ export default function Debt() {
                     getBorrowableAmount(collateral, debt, rateOfEthJpy, MCR),
                     'jpy'
                   ).value
-                }{YAMATO_SYMBOL.YEN}
+                }
+                {YAMATO_SYMBOL.YEN}
               </>
             ) : (
               <Skeleton

--- a/src/components/Pledge/Debt/index.tsx
+++ b/src/components/Pledge/Debt/index.tsx
@@ -40,75 +40,13 @@ export default function Debt() {
   const { cjpy } = useWalletState();
 
   return (
-    <Grid templateColumns="repeat(8, 1fr)" gap={4} mb={4}>
-      <GridItem colSpan={1}>
-        <ItemTitleForPledge marginTop={26}>借入量</ItemTitleForPledge>
-      </GridItem>
-
-      <GridItem colSpan={1}>
-        <ItemTitleValue
-          marginTop={26}
-          data-testid="borrowing-data-currentAmount"
-        >
-          {firstLoadCompleted ? (
-            <>
-              {formatPrice(debt, 'jpy').value}
-              {YAMATO_SYMBOL.YEN}
-            </>
-          ) : (
-            <Skeleton
-              height="1.4rem"
-              width="7rem"
-              style={{
-                lineHeight: '1.4rem',
-              }}
-            />
-          )}
-        </ItemTitleValue>
-      </GridItem>
-
-      <GridItem colSpan={3}>
-        <BorrowInput
-          collateral={collateral}
-          debt={debt}
-          rateOfEthJpy={rateOfEthJpy}
-          MCR={MCR}
-        />
-      </GridItem>
-
-      <GridItem colSpan={3}>
-        <RepayInput
-          collateral={collateral}
-          debt={debt}
-          rateOfEthJpy={rateOfEthJpy}
-          cjpy={cjpy}
-        />
-      </GridItem>
-
-      <GridItem colSpan={1}>
-        <ItemTitleForPledge marginTop={26}>担保率</ItemTitleForPledge>
-      </GridItem>
-      <GridItem colSpan={1}>
-        <ItemTitleValue marginTop={26}>
-          {firstLoadCompleted ? (
-            <>
-              {formatCollateralizationRatio(collateral * rateOfEthJpy, debt)}%
-            </>
-          ) : (
-            <Skeleton
-              height="1.4rem"
-              width="7rem"
-              style={{
-                lineHeight: '1.4rem',
-              }}
-            />
-          )}
-        </ItemTitleValue>
-      </GridItem>
-      <GridItem colSpan={5}>
-        <div style={{ marginTop: '32px', textAlign: 'right' }}>
-          <Text>
-            最大借入可能量...
+    <>
+      <Grid templateColumns="repeat(8, 1fr)" gap={4} mb={4}>
+        <GridItem colSpan={1}>
+          <ItemTitleForPledge marginTop={26}>最大借入可能量</ItemTitleForPledge>
+        </GridItem>
+        <GridItem colSpan={1}>
+          <ItemTitleValue marginTop={26}>
             {firstLoadCompleted ? (
               <>
                 {
@@ -116,23 +54,87 @@ export default function Debt() {
                     getBorrowableAmount(collateral, debt, rateOfEthJpy, MCR),
                     'jpy'
                   ).value
-                }
+                }{YAMATO_SYMBOL.YEN}
               </>
             ) : (
               <Skeleton
                 height="1.4rem"
-                width="5rem"
+                width="7rem"
                 style={{
-                  display: 'inline-block',
-                  verticalAlign: 'middle',
                   lineHeight: '1.4rem',
                 }}
               />
             )}
-            {YAMATO_SYMBOL.YEN}
-          </Text>
-        </div>
-      </GridItem>
-    </Grid>
+          </ItemTitleValue>
+        </GridItem>
+      </Grid>
+      <Grid templateColumns="repeat(8, 1fr)" gap={4} mb={4}>
+        <GridItem colSpan={1}>
+          <ItemTitleForPledge marginTop={26}>借入量</ItemTitleForPledge>
+        </GridItem>
+
+        <GridItem colSpan={1}>
+          <ItemTitleValue
+            marginTop={26}
+            data-testid="borrowing-data-currentAmount"
+          >
+            {firstLoadCompleted ? (
+              <>
+                {formatPrice(debt, 'jpy').value}
+                {YAMATO_SYMBOL.YEN}
+              </>
+            ) : (
+              <Skeleton
+                height="1.4rem"
+                width="7rem"
+                style={{
+                  lineHeight: '1.4rem',
+                }}
+              />
+            )}
+          </ItemTitleValue>
+        </GridItem>
+
+        <GridItem colSpan={3}>
+          <BorrowInput
+            collateral={collateral}
+            debt={debt}
+            rateOfEthJpy={rateOfEthJpy}
+            MCR={MCR}
+          />
+        </GridItem>
+
+        <GridItem colSpan={3}>
+          <RepayInput
+            collateral={collateral}
+            debt={debt}
+            rateOfEthJpy={rateOfEthJpy}
+            cjpy={cjpy}
+          />
+        </GridItem>
+      </Grid>
+      <Grid templateColumns="repeat(8, 1fr)" gap={4} mb={4}>
+        <GridItem colSpan={1}>
+          <ItemTitleForPledge marginTop={26}>担保率</ItemTitleForPledge>
+        </GridItem>
+        <GridItem colSpan={1}>
+          <ItemTitleValue marginTop={26}>
+            {firstLoadCompleted ? (
+              <>
+                {formatCollateralizationRatio(collateral * rateOfEthJpy, debt)}%
+              </>
+            ) : (
+              <Skeleton
+                height="1.4rem"
+                width="7rem"
+                style={{
+                  lineHeight: '1.4rem',
+                }}
+              />
+            )}
+          </ItemTitleValue>
+        </GridItem>
+      </Grid>
+    </>
   );
 }

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -80,7 +80,7 @@ export function formatCollateralizationRatio(
   if (debt === 0) {
     return '0.00';
   }
-  return (divideToNum(collateral, debt) * 100).toLocaleString(undefined, {
+  return (Math.min(divideToNum(collateral, debt) * 100, 9999.9)).toLocaleString(undefined, {
     maximumFractionDigits: 2,
   });
 }

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -80,9 +80,12 @@ export function formatCollateralizationRatio(
   if (debt === 0) {
     return '0.00';
   }
-  return (Math.min(divideToNum(collateral, debt) * 100, 9999.9)).toLocaleString(undefined, {
-    maximumFractionDigits: 2,
-  });
+  return Math.min(divideToNum(collateral, debt) * 100, 9999.9).toLocaleString(
+    undefined,
+    {
+      maximumFractionDigits: 2,
+    }
+  );
 }
 
 export function getEthChangePercent(current: number, previous: number): number {


### PR DESCRIPTION
fix: https://github.com/DeFiGeek-Community/yamato-interface/issues/108

対応後イメージ
![image](https://user-images.githubusercontent.com/32897506/153760330-d72453d6-9b51-4c99-adbf-3089a1e46f25.png)

担保率の9999.9％の閾値での変化を確認

- 変動予測値と担保率を改行する
- ラベルと数値は半角スペースで切る
- 最大借入可能量を借入量の上に配置（比較しやすくするため）
