### PR TITLE
fix: issue#104

### DIFF
--- a/src/components/Pledge/Collateral/DepositInput.tsx
+++ b/src/components/Pledge/Collateral/DepositInput.tsx
@@ -63,7 +63,7 @@ export default function DepositInput(props: Props) {
           errorToast('預入量が0です。');
           return;
         }
-  
+
         try {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const res = await callback!(values.deposit);

--- a/src/components/Pledge/Collateral/DepositInput.tsx
+++ b/src/components/Pledge/Collateral/DepositInput.tsx
@@ -51,26 +51,28 @@ export default function DepositInput(props: Props) {
 
   const submitDeposit = useCallback(
     async (
-      values: { deposit: string },
+      values: { deposit: number | string },
       formikHelpers: FormikHelpers<{
-        deposit: string;
+        deposit: number | string;
       }>
     ) => {
       console.debug('submit deposit', values);
 
-      if (typeof values.deposit === 'number') {
-        if (values.deposit <= 0) {
-          errorToast('預入量が0です。');
-          return;
-        }
+      if (typeof values.deposit !== 'number') {
+        return;
+      }
 
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const res = await callback!(values.deposit);
-          console.debug('deposit done', res);
-        } catch (error) {
-          errorToast(error);
-        }
+      if (values.deposit <= 0) {
+        errorToast('預入量が0です。');
+        return;
+      }
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const res = await callback!(values.deposit);
+        console.debug('deposit done', res);
+      } catch (error) {
+        errorToast(error);
       }
 
       // reset
@@ -81,7 +83,10 @@ export default function DepositInput(props: Props) {
   );
 
   return (
-    <Formik initialValues={{ deposit: '' }} onSubmit={submitDeposit}>
+    <Formik
+      initialValues={{ deposit: '' as number | string }}
+      onSubmit={submitDeposit}
+    >
       {(formikProps) => (
         <Form>
           <VStack spacing={4} align="start">

--- a/src/components/Pledge/Collateral/WithdrawalInput.tsx
+++ b/src/components/Pledge/Collateral/WithdrawalInput.tsx
@@ -29,15 +29,15 @@ export default function WithdrawalInput(props: Props) {
   const { account } = useActiveWeb3React();
   const { callback } = useWithdrawCallback();
 
-  const [withdrawal, setWithdrawal] = useState(0);
+  const [withdrawal, setWithdrawal] = useState<number | string>();
 
   const validateWithdrawal = useCallback(
-    (value: number) => {
+    (value: number | string) => {
       if (!account || !callback) {
         return `ウォレットを接続してください。またはネットワークを切り替えてください。`;
       }
 
-      if (value == null || typeof value !== 'number') {
+      if (value !== '' && typeof value !== 'number') {
         return '数値で入力してください。';
       }
       if (value > collateral) {
@@ -53,30 +53,32 @@ export default function WithdrawalInput(props: Props) {
 
   const submitWithdrawal = useCallback(
     async (
-      values: { withdrawal: number },
+      values: { withdrawal: string },
       formikHelpers: FormikHelpers<{
-        withdrawal: number;
+        withdrawal: string;
       }>
     ) => {
       console.debug('submit withdrawal', values);
-
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const res = await callback!(values.withdrawal);
-        console.debug('withdrawal done', res);
-      } catch (error) {
-        errorToast(error);
+      
+      if (typeof values.withdrawal === 'number') {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const res = await callback!(values.withdrawal);
+          console.debug('withdrawal done', res);
+        } catch (error) {
+          errorToast(error);
+        }
+  
+        // reset
+        setWithdrawal('');
+        formikHelpers.resetForm();
       }
-
-      // reset
-      setWithdrawal(0);
-      formikHelpers.resetForm();
     },
     [callback]
   );
 
   return (
-    <Formik initialValues={{ withdrawal: 0 }} onSubmit={submitWithdrawal}>
+    <Formik initialValues={{ withdrawal: '' }} onSubmit={submitWithdrawal}>
       {(formikProps) => (
         <Form>
           <VStack spacing={4} align="start">
@@ -112,20 +114,21 @@ export default function WithdrawalInput(props: Props) {
                 isLoading={formikProps.isSubmitting}
                 type="submit"
                 data-testid="collateral-act-withdraw"
+                isDisabled={typeof withdrawal !== 'number'}
               >
                 引出実行
               </CustomButton>
             </HStack>
-            {withdrawal > 0 && (
+            {typeof withdrawal === 'number' && withdrawal > 0 && (
               <VStack spacing={4} align="start">
                 <CustomFormLabel
                   text={`変動予測値 ${
                     formatPrice(subtractToNum(collateral, withdrawal), 'jpy')
                       .value
-                  } ${YAMATO_SYMBOL.COLLATERAL}`}
-                />
-                <CustomFormLabel
-                  text={`担保率 ${formatCollateralizationRatio(
+                    } ${YAMATO_SYMBOL.COLLATERAL}`}
+                    />
+                    <CustomFormLabel
+                      text={`担保率 ${formatCollateralizationRatio(
                     (collateral - withdrawal) * rateOfEthJpy,
                     debt
                   )}%`}

--- a/src/components/Pledge/Collateral/WithdrawalInput.tsx
+++ b/src/components/Pledge/Collateral/WithdrawalInput.tsx
@@ -59,7 +59,7 @@ export default function WithdrawalInput(props: Props) {
       }>
     ) => {
       console.debug('submit withdrawal', values);
-      
+
       if (typeof values.withdrawal === 'number') {
         try {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -68,7 +68,7 @@ export default function WithdrawalInput(props: Props) {
         } catch (error) {
           errorToast(error);
         }
-  
+
         // reset
         setWithdrawal('');
         formikHelpers.resetForm();
@@ -125,10 +125,10 @@ export default function WithdrawalInput(props: Props) {
                   text={`変動予測値 ${
                     formatPrice(subtractToNum(collateral, withdrawal), 'jpy')
                       .value
-                    } ${YAMATO_SYMBOL.COLLATERAL}`}
-                    />
-                    <CustomFormLabel
-                      text={`担保率 ${formatCollateralizationRatio(
+                  } ${YAMATO_SYMBOL.COLLATERAL}`}
+                />
+                <CustomFormLabel
+                  text={`担保率 ${formatCollateralizationRatio(
                     (collateral - withdrawal) * rateOfEthJpy,
                     debt
                   )}%`}

--- a/src/components/Pledge/Collateral/WithdrawalInput.tsx
+++ b/src/components/Pledge/Collateral/WithdrawalInput.tsx
@@ -53,32 +53,37 @@ export default function WithdrawalInput(props: Props) {
 
   const submitWithdrawal = useCallback(
     async (
-      values: { withdrawal: string },
+      values: { withdrawal: number | string },
       formikHelpers: FormikHelpers<{
-        withdrawal: string;
+        withdrawal: number | string;
       }>
     ) => {
       console.debug('submit withdrawal', values);
 
-      if (typeof values.withdrawal === 'number') {
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const res = await callback!(values.withdrawal);
-          console.debug('withdrawal done', res);
-        } catch (error) {
-          errorToast(error);
-        }
-
-        // reset
-        setWithdrawal('');
-        formikHelpers.resetForm();
+      if (typeof values.withdrawal !== 'number') {
+        return;
       }
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const res = await callback!(values.withdrawal);
+        console.debug('withdrawal done', res);
+      } catch (error) {
+        errorToast(error);
+      }
+
+      // reset
+      setWithdrawal('');
+      formikHelpers.resetForm();
     },
     [callback]
   );
 
   return (
-    <Formik initialValues={{ withdrawal: '' }} onSubmit={submitWithdrawal}>
+    <Formik
+      initialValues={{ withdrawal: '' as number | string }}
+      onSubmit={submitWithdrawal}
+    >
       {(formikProps) => (
         <Form>
           <VStack spacing={4} align="start">

--- a/src/components/Pledge/Debt/BorrowingInput.tsx
+++ b/src/components/Pledge/Debt/BorrowingInput.tsx
@@ -38,7 +38,8 @@ export default function BorrowingInput(props: Props) {
       if (debt + borrowing <= 0) {
         return { fee: 0, feeRate: 0 };
       }
-      const ICR = divideToNum(collateral * rateOfEthJpy, debt + borrowing) * 100;
+      const ICR =
+        divideToNum(collateral * rateOfEthJpy, debt + borrowing) * 100;
       return calcFee(borrowing, ICR);
     } else {
       return { fee: 0, feeRate: 0 };
@@ -60,7 +61,7 @@ export default function BorrowingInput(props: Props) {
         if (MCR > collateralRatio) {
           return `担保率は最低${MCR}%が必要です。`;
         }
-      } else if (value !== ''){
+      } else if (value !== '') {
         return '数値で入力してください。';
       }
 
@@ -87,11 +88,11 @@ export default function BorrowingInput(props: Props) {
           console.debug('borrowing done', res);
         } catch (error) {
           errorToast(error);
-        }  
+        }
 
-      // reset
-      setBorrowing('');
-      formikHelpers.resetForm();
+        // reset
+        setBorrowing('');
+        formikHelpers.resetForm();
       }
     },
     [callback]

--- a/src/components/Pledge/Debt/BorrowingInput.tsx
+++ b/src/components/Pledge/Debt/BorrowingInput.tsx
@@ -31,33 +31,37 @@ export default function BorrowingInput(props: Props) {
   const { account } = useActiveWeb3React();
   const { callback } = useBorrowCallback();
 
-  const [borrowing, setBorrowing] = useState(0);
+  const [borrowing, setBorrowing] = useState<number | string>();
 
   const feeResult = useMemo(() => {
-    if (debt + borrowing <= 0) {
+    if (typeof borrowing === 'number') {
+      if (debt + borrowing <= 0) {
+        return { fee: 0, feeRate: 0 };
+      }
+      const ICR = divideToNum(collateral * rateOfEthJpy, debt + borrowing) * 100;
+      return calcFee(borrowing, ICR);
+    } else {
       return { fee: 0, feeRate: 0 };
     }
-    const ICR = divideToNum(collateral * rateOfEthJpy, debt + borrowing) * 100;
-    return calcFee(borrowing, ICR);
   }, [collateral, debt, borrowing, rateOfEthJpy]);
 
   const validateBorrowing = useCallback(
-    async (value: number) => {
+    async (value: number | string) => {
       if (!account || !callback) {
         return `ウォレットを接続してください。またはネットワークを切り替えてください。`;
       }
 
-      if (value == null || typeof value !== 'number') {
+      if (typeof value === 'number') {
+        const sum = debt + value;
+        if (sum <= 0) {
+          return '数値で入力してください。';
+        }
+        const collateralRatio = ((collateral * rateOfEthJpy) / sum) * 100;
+        if (MCR > collateralRatio) {
+          return `担保率は最低${MCR}%が必要です。`;
+        }
+      } else if (value !== ''){
         return '数値で入力してください。';
-      }
-
-      const sum = debt + value;
-      if (sum <= 0) {
-        return '数値で入力してください。';
-      }
-      const collateralRatio = ((collateral * rateOfEthJpy) / sum) * 100;
-      if (MCR > collateralRatio) {
-        return `担保率は最低${MCR}%が必要です。`;
       }
 
       // Value is correct
@@ -69,30 +73,32 @@ export default function BorrowingInput(props: Props) {
 
   const submitBorrowing = useCallback(
     async (
-      values: { borrowing: number },
+      values: { borrowing: string },
       formikHelpers: FormikHelpers<{
-        borrowing: number;
+        borrowing: string;
       }>
     ) => {
       console.debug('submit borrowing', values);
 
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const res = await callback!(values.borrowing);
-        console.debug('borrowing done', res);
-      } catch (error) {
-        errorToast(error);
-      }
+      if (typeof values.borrowing === 'number') {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const res = await callback!(values.borrowing);
+          console.debug('borrowing done', res);
+        } catch (error) {
+          errorToast(error);
+        }  
 
       // reset
-      setBorrowing(0);
+      setBorrowing('');
       formikHelpers.resetForm();
+      }
     },
     [callback]
   );
 
   return (
-    <Formik initialValues={{ borrowing: 0 }} onSubmit={submitBorrowing}>
+    <Formik initialValues={{ borrowing: '' }} onSubmit={submitBorrowing}>
       {(formikProps) => (
         <Form>
           <VStack spacing={4} align="start">
@@ -128,11 +134,12 @@ export default function BorrowingInput(props: Props) {
                 isLoading={formikProps.isSubmitting}
                 type="submit"
                 data-testid="borrowing-act-borrow"
+                isDisabled={typeof borrowing !== 'number'}
               >
                 借入実行
               </CustomButton>
             </HStack>
-            {borrowing > 0 && (
+            {typeof borrowing === 'number' && borrowing > 0 && (
               <VStack spacing={4} align="start">
                 <CustomFormLabel
                   text={`変動予測値 ${

--- a/src/components/Pledge/Debt/BorrowingInput.tsx
+++ b/src/components/Pledge/Debt/BorrowingInput.tsx
@@ -74,32 +74,37 @@ export default function BorrowingInput(props: Props) {
 
   const submitBorrowing = useCallback(
     async (
-      values: { borrowing: string },
+      values: { borrowing: number | string },
       formikHelpers: FormikHelpers<{
-        borrowing: string;
+        borrowing: number | string;
       }>
     ) => {
       console.debug('submit borrowing', values);
 
-      if (typeof values.borrowing === 'number') {
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const res = await callback!(values.borrowing);
-          console.debug('borrowing done', res);
-        } catch (error) {
-          errorToast(error);
-        }
-
-        // reset
-        setBorrowing('');
-        formikHelpers.resetForm();
+      if (typeof values.borrowing !== 'number') {
+        return;
       }
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const res = await callback!(values.borrowing);
+        console.debug('borrowing done', res);
+      } catch (error) {
+        errorToast(error);
+      }
+
+      // reset
+      setBorrowing('');
+      formikHelpers.resetForm();
     },
     [callback]
   );
 
   return (
-    <Formik initialValues={{ borrowing: '' }} onSubmit={submitBorrowing}>
+    <Formik
+      initialValues={{ borrowing: '' as number | string }}
+      onSubmit={submitBorrowing}
+    >
       {(formikProps) => (
         <Form>
           <VStack spacing={4} align="start">

--- a/src/components/Pledge/Debt/RepayInput.tsx
+++ b/src/components/Pledge/Debt/RepayInput.tsx
@@ -58,21 +58,23 @@ export default function RepayInput(props: Props) {
 
   const submitRepayment = useCallback(
     async (
-      values: { repayment: string },
+      values: { repayment: number | string },
       formikHelpers: FormikHelpers<{
-        repayment: string;
+        repayment: number | string;
       }>
     ) => {
       console.debug('submit repayment', values);
 
-      if (typeof values.repayment === 'number') {
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const res = await callback!(values.repayment);
-          console.debug('repayment done', res);
-        } catch (error) {
-          errorToast(error);
-        }
+      if (typeof values.repayment !== 'number') {
+        return;
+      }
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const res = await callback!(values.repayment);
+        console.debug('repayment done', res);
+      } catch (error) {
+        errorToast(error);
       }
 
       // reset
@@ -83,7 +85,10 @@ export default function RepayInput(props: Props) {
   );
 
   return (
-    <Formik initialValues={{ repayment: '' }} onSubmit={submitRepayment}>
+    <Formik
+      initialValues={{ repayment: '' as number | string }}
+      onSubmit={submitRepayment}
+    >
       {(formikProps) => (
         <Form>
           <VStack spacing={4} align="start">

--- a/src/components/Pledge/Debt/RepayInput.tsx
+++ b/src/components/Pledge/Debt/RepayInput.tsx
@@ -31,15 +31,15 @@ export default function RepayInput(props: Props) {
   const { account } = useActiveWeb3React();
   const { callback } = useRepayCallback();
 
-  const [repayment, setRepayment] = useState(0);
+  const [repayment, setRepayment] = useState<number | string>();
 
   const validateRepayment = useCallback(
-    (value: number) => {
+    (value: number | string) => {
       if (!account || !callback) {
         return `ウォレットを接続してください。またはネットワークを切り替えてください。`;
       }
 
-      if (value == null || typeof value !== 'number') {
+      if (value !== '' && typeof value !== 'number') {
         return '数値で入力してください。';
       }
       if (value > debt) {
@@ -58,30 +58,32 @@ export default function RepayInput(props: Props) {
 
   const submitRepayment = useCallback(
     async (
-      values: { repayment: number },
+      values: { repayment: string },
       formikHelpers: FormikHelpers<{
-        repayment: number;
+        repayment: string;
       }>
     ) => {
       console.debug('submit repayment', values);
 
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const res = await callback!(values.repayment);
-        console.debug('repayment done', res);
-      } catch (error) {
-        errorToast(error);
+      if (typeof values.repayment === 'number') {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const res = await callback!(values.repayment);
+          console.debug('repayment done', res);
+        } catch (error) {
+          errorToast(error);
+        }        
       }
 
       // reset
-      setRepayment(0);
+      setRepayment('');
       formikHelpers.resetForm();
     },
     [callback]
   );
 
   return (
-    <Formik initialValues={{ repayment: 0 }} onSubmit={submitRepayment}>
+    <Formik initialValues={{ repayment: '' }} onSubmit={submitRepayment}>
       {(formikProps) => (
         <Form>
           <VStack spacing={4} align="start">
@@ -130,11 +132,12 @@ export default function RepayInput(props: Props) {
                 isLoading={formikProps.isSubmitting}
                 type="submit"
                 data-testid="borrowing-act-repay"
+                isDisabled={typeof repayment !== 'number'}
               >
                 返済実行
               </CustomButton>
             </HStack>
-            {repayment > 0 && (
+            {typeof repayment === 'number' && repayment > 0 && (
               <VStack spacing={4} align="start">
                 <CustomFormLabel
                   text={`変動予測値 ${

--- a/src/components/Pledge/Debt/RepayInput.tsx
+++ b/src/components/Pledge/Debt/RepayInput.tsx
@@ -72,7 +72,7 @@ export default function RepayInput(props: Props) {
           console.debug('repayment done', res);
         } catch (error) {
           errorToast(error);
-        }        
+        }
       }
 
       // reset

--- a/src/components/Redemption/SelfRedemption/RedemptionInput.tsx
+++ b/src/components/Redemption/SelfRedemption/RedemptionInput.tsx
@@ -71,25 +71,27 @@ export default function RedemptionInput(props: Props) {
 
   const submitRedemption = useCallback(
     async (
-      values: { redemption: string },
+      values: { redemption: number | string },
       formikHelpers: FormikHelpers<{
-        redemption: string;
+        redemption: number | string;
       }>
     ) => {
       console.debug('submit self redemption', values);
 
-      if (typeof values.redemption === 'number') {
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const res = await callback!(
-            'selfRedeem',
-            values.redemption,
-            formattedRedeemableCandidate.eth
-          );
-          console.debug('self redemption done', res);
-        } catch (error) {
-          errorToast(error);
-        }
+      if (typeof values.redemption !== 'number') {
+        return;
+      }
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const res = await callback!(
+          'selfRedeem',
+          values.redemption,
+          formattedRedeemableCandidate.eth
+        );
+        console.debug('self redemption done', res);
+      } catch (error) {
+        errorToast(error);
       }
 
       // reset
@@ -100,7 +102,10 @@ export default function RedemptionInput(props: Props) {
   );
 
   return (
-    <Formik initialValues={{ redemption: '' }} onSubmit={submitRedemption}>
+    <Formik
+      initialValues={{ redemption: '' as number | string }}
+      onSubmit={submitRedemption}
+    >
       {(formikProps) => (
         <Form>
           <Grid templateColumns="repeat(4, 1fr)" gap={4}>

--- a/src/components/Redemption/SelfRedemption/RedemptionInput.tsx
+++ b/src/components/Redemption/SelfRedemption/RedemptionInput.tsx
@@ -39,19 +39,19 @@ export default function RedemptionInput(props: Props) {
   const { callback } = useRedeemCallback();
   const { cjpy } = useWalletState();
 
-  const [redemption, setRedemption] = useState(0);
+  const [redemption, setRedemption] = useState<number | string>();
   const formattedRedeemableCandidate = getRedeemableCandidate(
     redeemableCandidate,
     rateOfEthJpy
   );
 
   const validateRedemption = useCallback(
-    async (value: number) => {
+    async (value: number | string) => {
       if (!account || !callback) {
         return `ウォレットを接続してください。またはネットワークを切り替えてください。`;
       }
 
-      if (value == null || typeof value !== 'number') {
+      if (value !== '' && typeof value !== 'number') {
         return '数値で入力してください。';
       }
       if (value > cjpy) {
@@ -71,34 +71,36 @@ export default function RedemptionInput(props: Props) {
 
   const submitRedemption = useCallback(
     async (
-      values: { redemption: number },
+      values: { redemption: string },
       formikHelpers: FormikHelpers<{
-        redemption: number;
+        redemption: string;
       }>
     ) => {
       console.debug('submit self redemption', values);
 
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const res = await callback!(
-          'selfRedeem',
-          values.redemption,
-          formattedRedeemableCandidate.eth
-        );
-        console.debug('self redemption done', res);
-      } catch (error) {
-        errorToast(error);
+      if (typeof values.redemption === 'number') {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const res = await callback!(
+            'selfRedeem',
+            values.redemption,
+            formattedRedeemableCandidate.eth
+          );
+          console.debug('self redemption done', res);
+        } catch (error) {
+          errorToast(error);
+        }
       }
 
       // reset
-      setRedemption(0);
+      setRedemption('');
       formikHelpers.resetForm();
     },
     [formattedRedeemableCandidate, callback]
   );
 
   return (
-    <Formik initialValues={{ redemption: 0 }} onSubmit={submitRedemption}>
+    <Formik initialValues={{ redemption: '' }} onSubmit={submitRedemption}>
       {(formikProps) => (
         <Form>
           <Grid templateColumns="repeat(4, 1fr)" gap={4}>
@@ -125,7 +127,7 @@ export default function RedemptionInput(props: Props) {
                   </FormControl>
                 )}
               </Field>
-              {redemption > 0 && (
+              {typeof redemption === 'number' && redemption > 0 && (
                 <VStack align="start" mt={4}>
                   <CustomFormLabel text="予想担保獲得量" />
                   <Text>
@@ -188,6 +190,7 @@ export default function RedemptionInput(props: Props) {
                 <CustomButton
                   isLoading={formikProps.isSubmitting}
                   type="submit"
+                  isDisabled={typeof redemption !== 'number'}
                 >
                   償還実行
                 </CustomButton>


### PR DESCRIPTION
fix: https://github.com/DeFiGeek-Community/yamato-interface/issues/104

- 初期値とメタマスクトランザクション発行後の初期値を空文字にする
- 空文字はバリデーションエラー対象としない
- 空文字のとき実行ボタンを非活性化

対応イメージ
![image](https://user-images.githubusercontent.com/32897506/154842099-6dab4643-bfb5-491e-aa2e-0eaac075eb3f.png)
