### PR TITLE
fix: correspond with subgraph

### DIFF
--- a/src/utils/fetchState/fetchSubgraph.ts
+++ b/src/utils/fetchState/fetchSubgraph.ts
@@ -19,6 +19,9 @@ interface YamatoCurentState {
   sweepablePledges: [Pledge];
 }
 
+/**
+ * Cache to reduce the numbers of communications;
+ */
 let cache: {
   yamatoEntiretyState: YamatoEntiretyState;
   pledge: PledgeState['list'];
@@ -52,7 +55,7 @@ const currentStateQuery = gql`
       lastPrice
       priceChange
     }
-    events(first: 20) {
+    events(first: 20, orderBy: date, orderDirection: desc) {
       id
       date
       category


### PR DESCRIPTION
以下の点についてsubgraphに合わせて修正した。

- Real Time Txに関して：デフォルトの場合、Graphはランダムな20個（正確にはTxIDの小さい順）にEventを返します。
そのため、dateでorderByフィルタをかけ、orderDirectionで最新順（＝dateの大きい順）にすることで期待する結果がが得られると思います。
- TVLについて。TVLはGraphが返すものが正しいと思います。現在のグラフ未使用の方のAppではTVLをPool ContractのETH残高と見做していますが、実際のTVL（Pledge残高の合計）はPool ContractのETH残高より少ないです。