### PR TITLE
fix(deposit,withdraw): set minimum collateral

### DIFF
--- a/src/components/Pledge/Collateral/DepositInput.tsx
+++ b/src/components/Pledge/Collateral/DepositInput.tsx
@@ -6,7 +6,7 @@ import {
 } from '@chakra-ui/react';
 import { Formik, Form, Field, FormikHelpers, FieldProps } from 'formik';
 import { useCallback, useState } from 'react';
-import { YAMATO_SYMBOL } from '../../../constants/yamato';
+import { MIN_COLLATERAL, YAMATO_SYMBOL } from '../../../constants/yamato';
 import { useActiveWeb3React } from '../../../hooks/web3';
 import { useDepositCallback } from '../../../hooks/yamato/useDepositCallback';
 import { useWalletState } from '../../../state/wallet/hooks';
@@ -40,6 +40,11 @@ export default function DepositInput(props: Props) {
       }
       if (value > eth) {
         return '残高を超えています。';
+      }
+      if (value < MIN_COLLATERAL - collateral) {
+        return (
+          '最小担保量は' + MIN_COLLATERAL + YAMATO_SYMBOL.COLLATERAL + 'です。'
+        );
       }
 
       // Value is correct

--- a/src/components/Pledge/Collateral/WithdrawalInput.tsx
+++ b/src/components/Pledge/Collateral/WithdrawalInput.tsx
@@ -6,7 +6,7 @@ import {
 } from '@chakra-ui/react';
 import { Formik, Form, Field, FormikHelpers, FieldProps } from 'formik';
 import { useCallback, useState } from 'react';
-import { YAMATO_SYMBOL } from '../../../constants/yamato';
+import { MIN_COLLATERAL, YAMATO_SYMBOL } from '../../../constants/yamato';
 import { useActiveWeb3React } from '../../../hooks/web3';
 import { useWithdrawCallback } from '../../../hooks/yamato/useWithdrawCallback';
 import { subtractToNum } from '../../../utils/bignumber';
@@ -43,7 +43,12 @@ export default function WithdrawalInput(props: Props) {
       if (value > collateral) {
         return '担保量を超えています。';
       }
-
+      console.log(value, typeof value, collateral, MIN_COLLATERAL,collateral - MIN_COLLATERAL,value > collateral - MIN_COLLATERAL);
+      if (value > collateral - MIN_COLLATERAL && value !== collateral) {
+        return (
+          '最小担保量は' + MIN_COLLATERAL + YAMATO_SYMBOL.COLLATERAL + 'です。'
+        );
+      }
       // Value is correct
       setWithdrawal(value);
       return undefined;

--- a/src/components/Pledge/Collateral/WithdrawalInput.tsx
+++ b/src/components/Pledge/Collateral/WithdrawalInput.tsx
@@ -43,7 +43,6 @@ export default function WithdrawalInput(props: Props) {
       if (value > collateral) {
         return '担保量を超えています。';
       }
-      console.log(value, typeof value, collateral, MIN_COLLATERAL,collateral - MIN_COLLATERAL,value > collateral - MIN_COLLATERAL);
       if (value > collateral - MIN_COLLATERAL && value !== collateral) {
         return (
           '最小担保量は' + MIN_COLLATERAL + YAMATO_SYMBOL.COLLATERAL + 'です。'

--- a/src/constants/yamato.ts
+++ b/src/constants/yamato.ts
@@ -46,7 +46,7 @@ export const REVERT_REASON_DESCRIPTION = {
   justReverted:
     '不明なエラーが発生しました。またはネットワークを切り替えてください。',
   walletRejected: '送信を取り止めました。',
-  zeroInput: '入力値が０です。または小さすぎます。',
+  zeroInput: '入力値が0です。または小さすぎます。',
 };
 
 export const ErrorToastConfig: UseToastOptions = {
@@ -56,3 +56,5 @@ export const ErrorToastConfig: UseToastOptions = {
   position: 'top',
   isClosable: true,
 };
+
+export const MIN_COLLATERAL = 0.1;


### PR DESCRIPTION
預け入れ後の最小担保量を0.1以上にする
引き出し後の最小担保量を0.1以上にする（借り入れがない場合のみ全額引き出し可能）

償還によって最小担保量が0.1を下回ることがあるが、その場合は追加の預け入れ・追加の償還で是正される。

https://discord.com/channels/705052448418693180/807606947074932736/956901201239240746