### PR TITLE
Fix(functions)  refactor sweep and redeem

### DIFF
--- a/src/components/Redemption/CoreRedemption/RedemptionInput.tsx
+++ b/src/components/Redemption/CoreRedemption/RedemptionInput.tsx
@@ -33,13 +33,19 @@ export default function RedemptionInput(props: Props) {
     () => getRedeemableCandidate(redeemableCandidate, rateOfEthJpy),
     [redeemableCandidate, rateOfEthJpy]
   );
+  const formattedRedemptionReserve = useMemo(
+    () => getRedeemableCandidate(redemptionReserve, rateOfEthJpy),
+    [redemptionReserve, rateOfEthJpy]
+  );
   const expectedReward = useMemo(
     () =>
       getExpectedReward(
-        Math.min(redemptionReserve, formattedRedeemableCandidate.eth),
-        GRR
+        Math.min(redemptionReserve, formattedRedeemableCandidate.cjpy),
+        true,
+        GRR,
+        rateOfEthJpy
       ),
-    [redemptionReserve, formattedRedeemableCandidate, GRR]
+    [redemptionReserve, formattedRedeemableCandidate, GRR, rateOfEthJpy]
   );
 
   const submitRedemption = useCallback(
@@ -59,8 +65,8 @@ export default function RedemptionInput(props: Props) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const res = await callback!(
           'coreRedeem',
-          Math.min(redemptionReserve, formattedRedeemableCandidate.eth),
-          expectedReward
+          Math.min(redemptionReserve, formattedRedeemableCandidate.cjpy),
+          expectedReward.eth
         );
         console.debug('core redemption done', res);
       } catch (error) {
@@ -90,9 +96,9 @@ export default function RedemptionInput(props: Props) {
                 <Text>
                   {firstLoadCompleted ? (
                     <>
-                      {formatPrice(redemptionReserve, 'jpy').value}
+                      {formatPrice(formattedRedemptionReserve.eth, 'eth').value}
                       {` `}
-                      {YAMATO_SYMBOL.YEN}
+                      {YAMATO_SYMBOL.COLLATERAL}
                     </>
                   ) : (
                     <Skeleton
@@ -103,6 +109,11 @@ export default function RedemptionInput(props: Props) {
                       }}
                     />
                   )}
+                </Text>
+                <Text>
+                  ({formatPrice(formattedRedemptionReserve.cjpy, 'jpy').value}
+                  {` `}
+                  {YAMATO_SYMBOL.YEN})
                 </Text>
               </VStack>
             </GridItem>
@@ -145,7 +156,7 @@ export default function RedemptionInput(props: Props) {
                 <Text>
                   {firstLoadCompleted ? (
                     <>
-                      {formatPrice(expectedReward, 'eth').value}
+                      {formatPrice(expectedReward.eth, 'eth').value}
                       {` `}
                       {YAMATO_SYMBOL.COLLATERAL}
                     </>

--- a/src/components/Redemption/SelfRedemption/RedemptionInput.tsx
+++ b/src/components/Redemption/SelfRedemption/RedemptionInput.tsx
@@ -7,7 +7,7 @@ import {
   VStack,
 } from '@chakra-ui/react';
 import { Formik, Form, Field, FieldProps, FormikHelpers } from 'formik';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { YAMATO_SYMBOL } from '../../../constants/yamato';
 import { useActiveWeb3React } from '../../../hooks/web3';
 import { useRedeemCallback } from '../../../hooks/yamato/useRedemption';
@@ -20,10 +20,7 @@ import {
   CustomFormLabel,
   CustomInput,
 } from '../../CommonItem';
-import {
-  getExpectedCollateral,
-  getRedeemableCandidate,
-} from '../shared/function';
+import { getExpectedReward, getRedeemableCandidate } from '../shared/function';
 
 type Props = {
   redeemableCandidate: number;
@@ -40,9 +37,9 @@ export default function RedemptionInput(props: Props) {
   const { cjpy } = useWalletState();
 
   const [redemption, setRedemption] = useState<number | string>();
-  const formattedRedeemableCandidate = getRedeemableCandidate(
-    redeemableCandidate,
-    rateOfEthJpy
+  const formattedRedeemableCandidate = useMemo(
+    () => getRedeemableCandidate(redeemableCandidate, rateOfEthJpy),
+    [redeemableCandidate, rateOfEthJpy]
   );
 
   const validateRedemption = useCallback(
@@ -138,12 +135,8 @@ export default function RedemptionInput(props: Props) {
                   <Text>
                     {
                       formatPrice(
-                        getExpectedCollateral(
-                          redemption,
-                          formattedRedeemableCandidate.eth,
-                          GRR,
-                          rateOfEthJpy
-                        ),
+                        getExpectedReward(redemption, false, GRR, rateOfEthJpy)
+                          .eth,
                         'eth'
                       ).value
                     }

--- a/src/components/Redemption/Sweep/SweepInput.tsx
+++ b/src/components/Redemption/Sweep/SweepInput.tsx
@@ -23,15 +23,17 @@ export default function SweepInput(props: Props) {
   const { account } = useActiveWeb3React();
   const { callback } = useSweepCallback();
 
+  const isCore = true;
+
   const expectedReward = useMemo(
     () =>
       getExpectedReward(
         Math.min(sweepReserve, sweepableCandiate),
-        true,
+        isCore,
         GRR,
         1
       ),
-    [sweepReserve, sweepableCandiate, GRR]
+    [sweepReserve, sweepableCandiate, isCore, GRR]
   );
 
   const submitSweep = useCallback(
@@ -49,7 +51,7 @@ export default function SweepInput(props: Props) {
 
       try {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const res = await callback!(sweepableCandiate);
+        const res = await callback!(expectedReward.cjpy);
         console.debug('sweep done', res);
       } catch (error) {
         errorToast(error);
@@ -58,7 +60,7 @@ export default function SweepInput(props: Props) {
       // reset
       formikHelpers.resetForm();
     },
-    [account, sweepableCandiate, callback]
+    [account, expectedReward, callback]
   );
 
   return (
@@ -134,6 +136,11 @@ export default function SweepInput(props: Props) {
                     />
                   )}
                 </Text>
+                <Text>
+                  ({formatPrice(expectedReward.eth, 'eth').value}
+                  {` `}
+                  {YAMATO_SYMBOL.COLLATERAL})
+                </Text>
               </VStack>
             </GridItem>
 
@@ -141,7 +148,7 @@ export default function SweepInput(props: Props) {
               <CustomButton
                 isLoading={formikProps.isSubmitting}
                 type="submit"
-                isDisabled={!expectedReward}
+                isDisabled={!expectedReward.cjpy}
               >
                 代位弁済実行
               </CustomButton>

--- a/src/components/Redemption/Sweep/SweepInput.tsx
+++ b/src/components/Redemption/Sweep/SweepInput.tsx
@@ -24,7 +24,13 @@ export default function SweepInput(props: Props) {
   const { callback } = useSweepCallback();
 
   const expectedReward = useMemo(
-    () => getExpectedReward(Math.min(sweepReserve, sweepableCandiate), GRR),
+    () =>
+      getExpectedReward(
+        Math.min(sweepReserve, sweepableCandiate),
+        true,
+        GRR,
+        1
+      ),
     [sweepReserve, sweepableCandiate, GRR]
   );
 
@@ -113,7 +119,7 @@ export default function SweepInput(props: Props) {
                 <Text>
                   {firstLoadCompleted ? (
                     <>
-                      {formatPrice(expectedReward, 'jpy').value}
+                      {formatPrice(expectedReward.cjpy, 'jpy').value}
                       {` `}
                       {YAMATO_SYMBOL.YEN}
                     </>

--- a/src/components/Redemption/shared/function.ts
+++ b/src/components/Redemption/shared/function.ts
@@ -16,22 +16,22 @@ export function getExpectedReward(
   return { eth, cjpy: candidateAmount };
 }
 
-export function getRedeemableCandidate(
-  redeemableCandidate: number,
+export function getEthAmountFromCjpy(
+  amountOfCjpy: number,
   rateOfEthJpy: number
 ): { eth: number; cjpy: number } {
-  if (!redeemableCandidate || !rateOfEthJpy) {
+  if (!amountOfCjpy || !rateOfEthJpy) {
     return { eth: 0, cjpy: 0 };
   }
 
-  const eth = convertEthFromCjpy(redeemableCandidate, rateOfEthJpy);
-  return { eth, cjpy: redeemableCandidate };
+  const eth = convertEthFromCjpy(amountOfCjpy, rateOfEthJpy);
+  return { eth, cjpy: amountOfCjpy };
 }
 
-export function convertEthFromCjpy(value: number, rateOfEthJpy: number) {
+export function convertEthFromCjpy(amountOfJpy: number, rateOfEthJpy: number) {
   if (!rateOfEthJpy) {
     return 0;
   }
-  const converted = value / rateOfEthJpy;
+  const converted = amountOfJpy / rateOfEthJpy;
   return converted;
 }

--- a/src/components/Redemption/shared/function.ts
+++ b/src/components/Redemption/shared/function.ts
@@ -1,27 +1,19 @@
-export function getExpectedCollateral(
-  redemption: number,
-  redeemableCandidate: number,
+export function getExpectedReward(
+  candidateAmount: number,
+  isCore: boolean,
   GRR: number,
   rateOfEthJpy: number
 ) {
-  if (!rateOfEthJpy) {
-    return 0;
+  if (candidateAmount <= 0 || !rateOfEthJpy) {
+    return { eth: 0, cjpy: 0 };
   }
-  const redemptionPerEth = redemption / rateOfEthJpy;
-  const redeemableAmount =
-    redemptionPerEth > redeemableCandidate
-      ? redeemableCandidate
-      : redemptionPerEth;
 
-  const expectedCollateral = redeemableAmount * ((100 - GRR) / 100);
-  return expectedCollateral;
-}
-
-export function getExpectedReward(candidateAmount: number, GRR: number) {
-  if (candidateAmount <= 0) {
-    return 0;
+  if (isCore) {
+    candidateAmount *= GRR / 100;
   }
-  return candidateAmount * (GRR / 100);
+
+  const eth = convertEthFromCjpy(candidateAmount, rateOfEthJpy);
+  return { eth, cjpy: candidateAmount };
 }
 
 export function getRedeemableCandidate(
@@ -32,7 +24,7 @@ export function getRedeemableCandidate(
     return { eth: 0, cjpy: 0 };
   }
 
-  const eth = redeemableCandidate / rateOfEthJpy;
+  const eth = convertEthFromCjpy(redeemableCandidate, rateOfEthJpy);
   return { eth, cjpy: redeemableCandidate };
 }
 

--- a/src/hooks/yamato/useRedemption.ts
+++ b/src/hooks/yamato/useRedemption.ts
@@ -20,7 +20,7 @@ export function useRedeemCallback(): {
     | null
     | ((
         sort: 'selfRedeem' | 'coreRedeem',
-        eth: number,
+        cjpy: number,
         expected: number
       ) => Promise<string>);
   error: string | null;
@@ -39,11 +39,11 @@ export function useRedeemCallback(): {
       state: CallbackState.VALID,
       callback: async function onRedeem(
         sort: 'selfRedeem' | 'coreRedeem',
-        eth: number,
+        cjpy: number,
         expected: number
       ): Promise<string> {
         // payload
-        const value = parseEther(eth.toString());
+        const value = parseEther(cjpy.toString());
         if (value.eq(BIGNUMBER_ZERO)) {
           throw new Error(REVERT_REASON_DESCRIPTION.zeroInput);
         }
@@ -62,12 +62,15 @@ export function useRedeemCallback(): {
         try {
           // send tx
           const params = { ...option, gasLimit: call.gasEstimate };
-          const response = await signer.redeem(value, false, params);
+          const isCore = sort === 'coreRedeem';
+          const response = await signer.redeem(value, isCore, params);
 
           // regist pending tx
           addTransaction(response, {
-            type: TransactionType.SELF_REDEEM,
-            value: eth,
+            type: isCore
+              ? TransactionType.CORE_REDEEM
+              : TransactionType.SELF_REDEEM,
+            value: cjpy,
             expected,
           });
 


### PR DESCRIPTION
CJPYからETH量を取得する関数の共通化
実行リワード予測関数の共通化
償還・Yamato償還のプール総量・候補総量のETH・CJPY位置の逆転
償還callbackのYamato・自己の分岐設定
弁済の実行リワード予測のETH表記追加